### PR TITLE
Replaced depreciated Chef::REST with Chef::ServerAPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: ruby
 
 rvm:
-  - 1.9.2
-  - 1.9.3
   - 2.0.0
   - 2.1
 
@@ -14,13 +12,3 @@ env:
   - CHEF_VERSION="= 12.0.0"
   - CHEF_VERSION="~> 12.0"
 
-matrix:
-  exclude:
-    - rvm: 1.9.2
-      env: CHEF_VERSION="= 12.0.0"
-    - rvm: 1.9.2
-      env: CHEF_VERSION="~> 12.0"
-    - rvm: 1.9.3
-      env: CHEF_VERSION="= 12.0.0"
-    - rvm: 1.9.3
-      env: CHEF_VERSION="~> 12.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rvm:
 sudo: false
 
 env:
-  - CHEF_VERSION="= 11.4.0"
+  - CHEF_VERSION="= 11.8.0"
   - CHEF_VERSION="~> 11.0"
   - CHEF_VERSION="= 12.0.0"
   - CHEF_VERSION="~> 12.0"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Node attributes are encrypted using chef client and user keys with public key in
 ## Requirements
 
 * Ruby `>= 1.9`
-* Chef Client `~> 11.4`
+* Chef Client `~> 11.8`
 * yajl_ruby `~> 1.1` or ffi_yajl `>= 1.0, <3.0` (included with Chef)
 * If you want to use protocol version 2 to use [GCM](http://en.wikipedia.org/wiki/Galois/Counter_Mode) (disabled by default):
  * Ruby `>= 2`.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Node attributes are encrypted using chef client and user keys with public key in
 
 ## Requirements
 
-* Ruby `>= 1.9`
+* Ruby `>= 2.0`
 * Chef Client `~> 11.8`
 * yajl_ruby `~> 1.1` or ffi_yajl `>= 1.0, <3.0` (included with Chef)
 * If you want to use protocol version 2 to use [GCM](http://en.wikipedia.org/wiki/Galois/Counter_Mode) (disabled by default):

--- a/chef-encrypted-attributes.gemspec
+++ b/chef-encrypted-attributes.gemspec
@@ -10,7 +10,7 @@ chef_version =
   if ENV.key?('CHEF_VERSION')
     ENV['CHEF_VERSION']
   else
-    ['>= 11.8', '< 13']
+    RUBY_VERSION < '2.1' ? ['>= 11.8', '< 12.9'] : ['>= 11.8', '< 13']
   end
 
 Gem::Specification.new do |s|
@@ -39,7 +39,6 @@ Gem::Specification.new do |s|
     s.add_development_dependency 'ffi-yajl',  '~> 2.2.3'
     s.add_development_dependency 'chef-zero', '< 4.6.0'
     s.add_development_dependency 'ohai', '< 8.18.0'
-    s.add_development_dependency 'chef', '< 12.9.0'
   end
 
   s.add_development_dependency 'rake', '~> 10.0'

--- a/chef-encrypted-attributes.gemspec
+++ b/chef-encrypted-attributes.gemspec
@@ -30,18 +30,11 @@ Gem::Specification.new do |s|
     .yardopts Rakefile LICENSE
   ) + Dir.glob('*.md') + Dir.glob('lib/**/*')
   s.test_files = Dir.glob('{test,spec,features}/*')
-  s.required_ruby_version = Gem::Requirement.new('>= 1.9.2')
+  s.required_ruby_version = Gem::Requirement.new('>= 2.0.0')
 
   s.add_development_dependency 'chef', chef_version
 
   # Support old deprecated Ruby versions:
-  if RUBY_VERSION < '1.9.3'
-    s.add_development_dependency 'mixlib-shellout', '< 1.6.1'
-  end
-  if RUBY_VERSION < '2'
-    s.add_development_dependency 'highline', '< 1.7'
-    s.add_development_dependency 'ohai', '< 8'
-  end
   if RUBY_VERSION < '2.1'
     s.add_development_dependency 'ffi-yajl',  '~> 2.2.3'
     s.add_development_dependency 'chef-zero', '< 4.6.0'

--- a/chef-encrypted-attributes.gemspec
+++ b/chef-encrypted-attributes.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
 
   # Support old deprecated Ruby versions:
   if RUBY_VERSION < '2.1'
-    s.add_development_dependency 'ffi-yajl',  '~> 2.2.3'
+    s.add_development_dependency 'ffi-yajl',  '<= 2.2.3'
     s.add_development_dependency 'chef-zero', '< 4.6.0'
     s.add_development_dependency 'ohai', '< 8.18.0'
   end

--- a/chef-encrypted-attributes.gemspec
+++ b/chef-encrypted-attributes.gemspec
@@ -44,7 +44,6 @@ Gem::Specification.new do |s|
   end
 
   s.add_development_dependency 'rake', '~> 10.0'
-  s.add_development_dependency 'chef-zero', '~> 4.6'
   s.add_development_dependency 'rack', '~> 1.0' if RUBY_VERSION < '2.2.2'
   s.add_development_dependency 'rspec-core', '~> 3.1'
   s.add_development_dependency 'rspec-expectations', '~> 3.1'

--- a/chef-encrypted-attributes.gemspec
+++ b/chef-encrypted-attributes.gemspec
@@ -10,7 +10,7 @@ chef_version =
   if ENV.key?('CHEF_VERSION')
     ENV['CHEF_VERSION']
   else
-    ['>= 11.4', '< 13']
+    ['>= 11.8', '< 13']
   end
 
 Gem::Specification.new do |s|
@@ -44,7 +44,8 @@ Gem::Specification.new do |s|
   end
 
   s.add_development_dependency 'rake', '~> 10.0'
-  s.add_development_dependency 'chef-zero', '~> 3.2'
+  s.add_development_dependency 'chef-zero', '~> 4.6'
+  s.add_development_dependency 'rack', '~> 1.0' if RUBY_VERSION < '2.2.2'
   s.add_development_dependency 'rspec-core', '~> 3.1'
   s.add_development_dependency 'rspec-expectations', '~> 3.1'
   s.add_development_dependency 'rspec-mocks', '~> 3.1'

--- a/chef-encrypted-attributes.gemspec
+++ b/chef-encrypted-attributes.gemspec
@@ -42,6 +42,12 @@ Gem::Specification.new do |s|
     s.add_development_dependency 'highline', '< 1.7'
     s.add_development_dependency 'ohai', '< 8'
   end
+  if RUBY_VERSION < '2.1'
+    s.add_development_dependency 'ffi-yajl',  '~> 2.2.3'
+    s.add_development_dependency 'chef-zero', '< 4.6.0'
+    s.add_development_dependency 'ohai', '< 8.18.0'
+    s.add_development_dependency 'chef', '< 12.9.0'
+  end
 
   s.add_development_dependency 'rake', '~> 10.0'
   s.add_development_dependency 'rack', '~> 1.0' if RUBY_VERSION < '2.2.2'

--- a/lib/chef/encrypted_attribute/search_helper.rb
+++ b/lib/chef/encrypted_attribute/search_helper.rb
@@ -17,6 +17,7 @@
 # limitations under the License.
 #
 
+require 'chef/server_api'
 require 'chef/search/query'
 require 'chef/encrypted_attribute/exceptions'
 
@@ -375,7 +376,7 @@ class Chef
         )
         assert_search_keys(keys)
 
-        rest = Chef::REST.new(Chef::Config[:chef_server_url])
+        rest = Chef::ServerAPI.new(Chef::Config[:chef_server_url])
         resp = rest.post_rest(escaped_query, generate_partial_search_keys(keys))
         assert_partial_search_response(resp)
         parse_partial_search_response(resp, name, keys)

--- a/lib/chef/encrypted_attribute/search_helper.rb
+++ b/lib/chef/encrypted_attribute/search_helper.rb
@@ -377,7 +377,7 @@ class Chef
         assert_search_keys(keys)
 
         rest = Chef::ServerAPI.new(Chef::Config[:chef_server_url])
-        resp = rest.post_rest(escaped_query, generate_partial_search_keys(keys))
+        resp = rest.post(escaped_query, generate_partial_search_keys(keys))
         assert_partial_search_response(resp)
         parse_partial_search_response(resp, name, keys)
       end

--- a/spec/integration/encrypted_attribute.rb
+++ b/spec/integration/encrypted_attribute.rb
@@ -19,6 +19,7 @@
 
 require 'integration_helper'
 require 'chef/api_client'
+require 'chef/node'
 
 describe Chef::EncryptedAttribute do
   extend ChefZero::RSpec

--- a/spec/unit/encrypted_attribute/search_helper.rb
+++ b/spec/unit/encrypted_attribute/search_helper.rb
@@ -425,7 +425,8 @@ describe Chef::EncryptedAttribute::SearchHelper do
 
     context 'searching by name' do
       before do
-        allow_any_instance_of(Chef::ServerAPI).to receive(:post_rest).and_return(
+        allow_any_instance_of(Chef::ServerAPI)
+          .to receive(:post_rest).and_return(
           'rows' => [
             { 'data' => { 'leo' => 'donnie', 'name' => 'node1' } },
             { 'data' => { 'raph' => 'mikey', 'name' => 'node2' } } # GH issue #3
@@ -442,7 +443,8 @@ describe Chef::EncryptedAttribute::SearchHelper do
       end
 
       it 'throws fatal error if returns multiple results' do
-        allow_any_instance_of(Chef::ServerAPI).to receive(:post_rest).and_return(
+        allow_any_instance_of(Chef::ServerAPI)
+          .to receive(:post_rest).and_return(
           'rows' => [
             { 'data' => { 'leo' => 'donnie', 'name' => 'node1' } },
             { 'data' => { 'raph' => 'mikey', 'name' => 'node1' } }

--- a/spec/unit/encrypted_attribute/search_helper.rb
+++ b/spec/unit/encrypted_attribute/search_helper.rb
@@ -153,7 +153,7 @@ describe Chef::EncryptedAttribute::SearchHelper do
 
     context 'with partial search' do
       it 'returns empty result for HTTP Not Found errors' do
-        expect_any_instance_of(Chef::REST).to receive(:post_rest)
+        expect_any_instance_of(Chef::ServerAPI).to receive(:post_rest)
           .and_raise(
             Net::HTTPServerException.new(
               'Net::HTTPServerException',
@@ -168,7 +168,7 @@ describe Chef::EncryptedAttribute::SearchHelper do
       end
 
       it 'throws search error for HTTP Server Exception errors' do
-        expect_any_instance_of(Chef::REST).to receive(:post_rest)
+        expect_any_instance_of(Chef::ServerAPI).to receive(:post_rest)
           .and_raise(Net::HTTPServerException.new('unit test', 0))
         expect do
           search_helper_class.search(
@@ -178,7 +178,7 @@ describe Chef::EncryptedAttribute::SearchHelper do
       end
 
       it 'throws search error for HTTP Fatal errors' do
-        expect_any_instance_of(Chef::REST).to receive(:post_rest)
+        expect_any_instance_of(Chef::ServerAPI).to receive(:post_rest)
           .and_raise(Net::HTTPFatalError.new('unit test', 0))
         expect do
           search_helper_class.search(
@@ -241,7 +241,7 @@ describe Chef::EncryptedAttribute::SearchHelper do
 
     context 'with partial search' do
       it 'returns empty result for HTTP Not Found errors' do
-        expect_any_instance_of(Chef::REST).to receive(:post_rest)
+        expect_any_instance_of(Chef::ServerAPI).to receive(:post_rest)
           .and_raise(
             Net::HTTPServerException.new(
               'Net::HTTPServerException',
@@ -256,7 +256,7 @@ describe Chef::EncryptedAttribute::SearchHelper do
       end
 
       it 'throws search error for HTTP Server Exception errors' do
-        expect_any_instance_of(Chef::REST).to receive(:post_rest)
+        expect_any_instance_of(Chef::ServerAPI).to receive(:post_rest)
           .and_raise(Net::HTTPServerException.new('unit test', 0))
         expect do
           search_helper_class.search_by_name(
@@ -266,7 +266,7 @@ describe Chef::EncryptedAttribute::SearchHelper do
       end
 
       it 'throws search error for HTTP Fatal errors' do
-        expect_any_instance_of(Chef::REST).to receive(:post_rest)
+        expect_any_instance_of(Chef::ServerAPI).to receive(:post_rest)
           .and_raise(Net::HTTPFatalError.new('unit test', 0))
         expect do
           search_helper_class.search_by_name(
@@ -376,7 +376,7 @@ describe Chef::EncryptedAttribute::SearchHelper do
 
   context '#partial_search' do
     before do
-      allow_any_instance_of(Chef::REST).to receive(:post_rest).and_return(
+      allow_any_instance_of(Chef::ServerAPI).to receive(:post_rest).and_return(
         'rows' => [
           { 'data' => { 'leo' => 'donnie' } },
           { 'data' => { 'raph' => 'mikey' } }
@@ -406,7 +406,7 @@ describe Chef::EncryptedAttribute::SearchHelper do
     end
 
     it 'throws fatal error for invalid search results' do
-      expect_any_instance_of(Chef::REST)
+      expect_any_instance_of(Chef::ServerAPI)
         .to receive(:post_rest).and_return('rows' => ':(')
       expect do
         search_helper_class
@@ -415,7 +415,7 @@ describe Chef::EncryptedAttribute::SearchHelper do
     end
 
     it 'throws fatal error for invalid row results' do
-      expect_any_instance_of(Chef::REST)
+      expect_any_instance_of(Chef::ServerAPI)
         .to receive(:post_rest).and_return('rows' => ['bad_data' => ':('])
       expect do
         search_helper_class
@@ -425,7 +425,7 @@ describe Chef::EncryptedAttribute::SearchHelper do
 
     context 'searching by name' do
       before do
-        allow_any_instance_of(Chef::REST).to receive(:post_rest).and_return(
+        allow_any_instance_of(Chef::ServerAPI).to receive(:post_rest).and_return(
           'rows' => [
             { 'data' => { 'leo' => 'donnie', 'name' => 'node1' } },
             { 'data' => { 'raph' => 'mikey', 'name' => 'node2' } } # GH issue #3
@@ -442,7 +442,7 @@ describe Chef::EncryptedAttribute::SearchHelper do
       end
 
       it 'throws fatal error if returns multiple results' do
-        allow_any_instance_of(Chef::REST).to receive(:post_rest).and_return(
+        allow_any_instance_of(Chef::ServerAPI).to receive(:post_rest).and_return(
           'rows' => [
             { 'data' => { 'leo' => 'donnie', 'name' => 'node1' } },
             { 'data' => { 'raph' => 'mikey', 'name' => 'node1' } }

--- a/spec/unit/encrypted_attribute/search_helper.rb
+++ b/spec/unit/encrypted_attribute/search_helper.rb
@@ -18,6 +18,7 @@
 #
 
 require 'spec_helper'
+require 'chef/node'
 
 describe Chef::EncryptedAttribute::SearchHelper do
   let(:search_helper_class) { Chef::EncryptedAttribute::SearchHelper }

--- a/spec/unit/encrypted_attribute/search_helper.rb
+++ b/spec/unit/encrypted_attribute/search_helper.rb
@@ -154,7 +154,7 @@ describe Chef::EncryptedAttribute::SearchHelper do
 
     context 'with partial search' do
       it 'returns empty result for HTTP Not Found errors' do
-        expect_any_instance_of(Chef::ServerAPI).to receive(:post_rest)
+        expect_any_instance_of(Chef::ServerAPI).to receive(:post)
           .and_raise(
             Net::HTTPServerException.new(
               'Net::HTTPServerException',
@@ -169,7 +169,7 @@ describe Chef::EncryptedAttribute::SearchHelper do
       end
 
       it 'throws search error for HTTP Server Exception errors' do
-        expect_any_instance_of(Chef::ServerAPI).to receive(:post_rest)
+        expect_any_instance_of(Chef::ServerAPI).to receive(:post)
           .and_raise(Net::HTTPServerException.new('unit test', 0))
         expect do
           search_helper_class.search(
@@ -179,7 +179,7 @@ describe Chef::EncryptedAttribute::SearchHelper do
       end
 
       it 'throws search error for HTTP Fatal errors' do
-        expect_any_instance_of(Chef::ServerAPI).to receive(:post_rest)
+        expect_any_instance_of(Chef::ServerAPI).to receive(:post)
           .and_raise(Net::HTTPFatalError.new('unit test', 0))
         expect do
           search_helper_class.search(
@@ -242,7 +242,7 @@ describe Chef::EncryptedAttribute::SearchHelper do
 
     context 'with partial search' do
       it 'returns empty result for HTTP Not Found errors' do
-        expect_any_instance_of(Chef::ServerAPI).to receive(:post_rest)
+        expect_any_instance_of(Chef::ServerAPI).to receive(:post)
           .and_raise(
             Net::HTTPServerException.new(
               'Net::HTTPServerException',
@@ -257,7 +257,7 @@ describe Chef::EncryptedAttribute::SearchHelper do
       end
 
       it 'throws search error for HTTP Server Exception errors' do
-        expect_any_instance_of(Chef::ServerAPI).to receive(:post_rest)
+        expect_any_instance_of(Chef::ServerAPI).to receive(:post)
           .and_raise(Net::HTTPServerException.new('unit test', 0))
         expect do
           search_helper_class.search_by_name(
@@ -267,7 +267,7 @@ describe Chef::EncryptedAttribute::SearchHelper do
       end
 
       it 'throws search error for HTTP Fatal errors' do
-        expect_any_instance_of(Chef::ServerAPI).to receive(:post_rest)
+        expect_any_instance_of(Chef::ServerAPI).to receive(:post)
           .and_raise(Net::HTTPFatalError.new('unit test', 0))
         expect do
           search_helper_class.search_by_name(
@@ -377,7 +377,7 @@ describe Chef::EncryptedAttribute::SearchHelper do
 
   context '#partial_search' do
     before do
-      allow_any_instance_of(Chef::ServerAPI).to receive(:post_rest).and_return(
+      allow_any_instance_of(Chef::ServerAPI).to receive(:post).and_return(
         'rows' => [
           { 'data' => { 'leo' => 'donnie' } },
           { 'data' => { 'raph' => 'mikey' } }
@@ -408,7 +408,7 @@ describe Chef::EncryptedAttribute::SearchHelper do
 
     it 'throws fatal error for invalid search results' do
       expect_any_instance_of(Chef::ServerAPI)
-        .to receive(:post_rest).and_return('rows' => ':(')
+        .to receive(:post).and_return('rows' => ':(')
       expect do
         search_helper_class
           .partial_search(:node, nil, '*:*', 'valid' => %w(keys))
@@ -417,7 +417,7 @@ describe Chef::EncryptedAttribute::SearchHelper do
 
     it 'throws fatal error for invalid row results' do
       expect_any_instance_of(Chef::ServerAPI)
-        .to receive(:post_rest).and_return('rows' => ['bad_data' => ':('])
+        .to receive(:post).and_return('rows' => ['bad_data' => ':('])
       expect do
         search_helper_class
           .partial_search(:node, nil, '*:*', 'valid' => %w(keys))
@@ -427,7 +427,7 @@ describe Chef::EncryptedAttribute::SearchHelper do
     context 'searching by name' do
       before do
         allow_any_instance_of(Chef::ServerAPI)
-          .to receive(:post_rest).and_return(
+          .to receive(:post).and_return(
             'rows' => [
               { 'data' => { 'leo' => 'donnie', 'name' => 'node1' } },
               { 'data' => { 'raph' => 'mikey', 'name' => 'node2' } }
@@ -446,7 +446,7 @@ describe Chef::EncryptedAttribute::SearchHelper do
 
       it 'throws fatal error if returns multiple results' do
         allow_any_instance_of(Chef::ServerAPI)
-          .to receive(:post_rest).and_return(
+          .to receive(:post).and_return(
             'rows' => [
               { 'data' => { 'leo' => 'donnie', 'name' => 'node1' } },
               { 'data' => { 'raph' => 'mikey', 'name' => 'node1' } }

--- a/spec/unit/encrypted_attribute/search_helper.rb
+++ b/spec/unit/encrypted_attribute/search_helper.rb
@@ -427,11 +427,12 @@ describe Chef::EncryptedAttribute::SearchHelper do
       before do
         allow_any_instance_of(Chef::ServerAPI)
           .to receive(:post_rest).and_return(
-          'rows' => [
-            { 'data' => { 'leo' => 'donnie', 'name' => 'node1' } },
-            { 'data' => { 'raph' => 'mikey', 'name' => 'node2' } } # GH issue #3
-          ]
-        )
+            'rows' => [
+              { 'data' => { 'leo' => 'donnie', 'name' => 'node1' } },
+              { 'data' => { 'raph' => 'mikey', 'name' => 'node2' } }
+              # GH issue #3
+            ]
+          )
       end
 
       it 'returns search results without errors' do
@@ -445,11 +446,11 @@ describe Chef::EncryptedAttribute::SearchHelper do
       it 'throws fatal error if returns multiple results' do
         allow_any_instance_of(Chef::ServerAPI)
           .to receive(:post_rest).and_return(
-          'rows' => [
-            { 'data' => { 'leo' => 'donnie', 'name' => 'node1' } },
-            { 'data' => { 'raph' => 'mikey', 'name' => 'node1' } }
-          ]
-        )
+            'rows' => [
+              { 'data' => { 'leo' => 'donnie', 'name' => 'node1' } },
+              { 'data' => { 'raph' => 'mikey', 'name' => 'node1' } }
+            ]
+          )
         expect do
           search_helper_class
             .partial_search(:node, 'node1', 'name:node1', 'valid' => %w(keys))


### PR DESCRIPTION
> Upgraded ChefDK and now knife encrypted attribute give me an error.
> Chef Development Kit Version: 0.15.15
> chef-client version: 12.11.18
> 
> Line 378 /lib/chef/encrypted_attribute/search_helper.rb is the problem.
> 
> Chef::REST is depreciated, simply replacing it with Chef::ServerAPI resolved the error.
